### PR TITLE
Fix grid

### DIFF
--- a/src/components/insta-grid/InstaGrid.tsx
+++ b/src/components/insta-grid/InstaGrid.tsx
@@ -11,6 +11,7 @@ interface InstaGridProps {
 
 const StyledGrid = styled.div`
   width: 100%;
+  aspect-ratio: 1 /1;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   grid-template-rows: repeat(3, 1fr);

--- a/src/components/media-item/MediaItem.tsx
+++ b/src/components/media-item/MediaItem.tsx
@@ -22,16 +22,16 @@ const iconStyle: SxProps<Theme> = {
 const MediaItem = ({ item }: MediaItemProps) => {
   const imageUrl = !!item.thumbnailUrl ? item.thumbnailUrl : item.mediaUrl;
   return (
-    <a
-      href={item.permalink}
-      target="_blank"
-      rel="noreferrer"
-    >
-      <div
-        style={{
-          display: "inline-block",
-          position: "relative"
-        }}>
+    <div
+      style={{
+        display: "inline-block",
+        position: "relative"
+      }}>
+      <a
+        href={item.permalink}
+        target="_blank"
+        rel="noreferrer"
+      >
         <img
           src={imageUrl}
           alt="insta-item"
@@ -49,8 +49,8 @@ const MediaItem = ({ item }: MediaItemProps) => {
         {item.mediaType === "CAROUSEL_ALBUM" &&
           <FilterNoneIcon sx={iconStyle} />
         }
-      </div>
-    </a>
+      </a>
+    </div>
   );
 }
 


### PR DESCRIPTION
1.) Fix height issue - for some the MediaItem height was off - wrapping the image and the icons inside an "a" tag caused the height to act up (it was slightly taller than it was wide, so not a square - maybe because it's styling issue with links). Placing the "a" tag inside the parent "div" fixes the issue.

2.) Forcing the entire grid to have aspect ratio 1/1 makes the whole thing a square. This ensures that text after the grid doesn't appear behind it (overlapping was an issue in the previous approach).